### PR TITLE
cleanup

### DIFF
--- a/meta-oe/recipes-oe-alliance/image/oe-alliance-base.bb
+++ b/meta-oe/recipes-oe-alliance/image/oe-alliance-base.bb
@@ -54,7 +54,6 @@ RDEPENDS:${PN} = "\
     packagegroup-base \
     packagegroup-core-boot \
     tzdata \
-    ${@bb.utils.contains("MACHINE_FEATURES", "smallflash", "tzdata-europe", "tzdata-europe tzdata-australia tzdata-asia tzdata-pacific tzdata-africa tzdata-americas", d)} \
     util-linux-sfdisk \
     util-linux-blkid \
     util-linux-flock \


### PR DESCRIPTION
tzdata: Install everything by default
I think this line is useless[ since](https://git.openembedded.org/openembedded-core/commit/meta/recipes-extended/timezone/tzdata.bb?id=2af4d6eb2526d60b26bc5128068541ff3350fb58) 2019-04-03.
Few kilobytes should be saved like [this](https://github.com/geeeeeeeeeee/oe-alliance-core/blob/5.1/meta-oe/recipes-extended/timezone/tzdata.bbappend) but not for smallflash only...

